### PR TITLE
fix anilist and jikan api

### DIFF
--- a/src/api/anilist.ts
+++ b/src/api/anilist.ts
@@ -39,7 +39,7 @@ export default class Anilist extends API<APIResult> {
 
   fetchURL(tab: string, query: string): { url: string, options: RequestInit } {
     const variables = {
-      search: encodeURI(query),
+      search: query,
       page: 1,
       type: tab.toUpperCase(),
       perPage: 15

--- a/src/api/jikan.ts
+++ b/src/api/jikan.ts
@@ -32,7 +32,7 @@ export default class Jikan extends APIWithShowMore<APIResult, APIShowMoreResult>
   fetchURL(tab: string, query: string): { url: string } {
     tab = this.denormalizeTab(tab)
     return {
-      url: `https://api.jikan.moe/v4/${tab}?limit=15&desc=desc&order_by=popularity&q=${encodeURI(query)}`
+      url: `https://api.jikan.moe/v4/${tab}?limit=15&sort=desc&order_by=favorites&q=${encodeURI(query)}`
     }
   }
   processResult(result: APIResult): SearchResult[] {


### PR DESCRIPTION
Noticed that some api functionalities weren't working:

1. Anilist/character. Does not work for full name search. For some reason AniList API doesn't accept spaces as `%20`. Since the api takes utf-8 for search queries it should be fine to remove the `encodeURI`.

2. Jikan. `sort` is broken due to a typo. From a few searches I've done `order_by` `popularity` doesn't seem to correlate with anything and the field also just straight up doesn't exist for characters so it seems more sensible to order by `favorites`

Cheers